### PR TITLE
Correct and refactor analysis() function

### DIFF
--- a/002_ml4analysis.R
+++ b/002_ml4analysis.R
@@ -31,9 +31,9 @@ library(GPArotation)
 library(tidyverse)
 
 ## NOTE: some analyses below require the full "merged" dataset, not deidentified (mostly due to age and gender variables). This is private due to participant confidentiality concerns, but inquire with Rick raklein22@gmail.com if you need it. (Typically requires IRB approval from your local institution indicating you'll keep the data properly protected)
-#merged <- readRDS("./data/processed_data/merged.rds")
+merged <- readRDS("./data/processed_data/merged.rds")
 #alternatively, you can run it with the public data and get most results
-merged <- readRDS("./data/public/merged_deidentified.rds")
+#merged <- readRDS("./data/public/merged_deidentified.rds")
 
 #Function to generate required stats for meta-analysis.
 analysis <- function(data, exclusionrule, sitesource)


### PR DESCRIPTION
The original `analysis2` and `analysis3` functions had NAs in the logical vector used to discard excluded data. This lead to samples being treated as though their post-exclusion sample size was larger than it actually was, e.g. riverside had 6 and 4 participants pass exclusion rule 2, but the code treated it as 13 and 13.

This pull request:
-Discards subjects with missing race or countryofbirth data for exclusion rules 2 and 3
-Discards subjects with missing americanid data for exclusion rule 3

Additionally, it refactors the separate analysis0, analysis1, analysis2, and analysis3 functions into a single `analysis` function. The user specifies the exclusion rule when calling analysis. For example, what was `analysis0(merged, "riverside")` is now `analysis(merged, "e0", riverside)`.

I did not continue my audit beyond "###Conducting a small meta-analysis of only the in-house data to provide a summary of those results in basic form.####". Please be careful to inspect that code for similar errors in the implementation of the exclusion rules.

Let me know if I can be of further help. I'd love to chip in.